### PR TITLE
fix: MQTT空ペイロード処理の改善

### DIFF
--- a/line_works/mqtt/client.py
+++ b/line_works/mqtt/client.py
@@ -113,7 +113,10 @@ class MQTTClient(BaseModel):
                     elif p.unique_id:
                         self._unique_ids.append(p.unique_id)
                 except PacketParseException as e:
-                    logger.debug("packet parse error", exc_info=e)
+                    logger.debug(
+                        f"packet parse error: {packet=}",
+                        exc_info=e
+                    )
                     return
 
             logger.debug(f"{packet=}")

--- a/line_works/mqtt/client.py
+++ b/line_works/mqtt/client.py
@@ -103,12 +103,18 @@ class MQTTClient(BaseModel):
             if packet.type == PacketType.PUBLISH:
                 try:
                     p = packet.payload
+                    if p is None:
+                        logger.debug(
+                            "Skipping packet with invalid or empty payload"
+                        )
+                        return
                     if p.unique_id in self._unique_ids:
                         return
                     elif p.unique_id:
                         self._unique_ids.append(p.unique_id)
                 except PacketParseException as e:
                     logger.debug("packet parse error", exc_info=e)
+                    return
 
             logger.debug(f"{packet=}")
 

--- a/line_works/mqtt/models/packet.py
+++ b/line_works/mqtt/models/packet.py
@@ -73,13 +73,13 @@ class MQTTPacket(BaseModel):
         return {}
 
     @property
-    def payload(self) -> PayloadTypes:
+    def payload(self) -> PayloadTypes | None:
         p = self.publish_payload
         if not (n_type := p.get("nType")):
-            raise PacketParseException(f"invalid payload: {p}")
+            return None
 
         if not (p_model := NOTIFICATION_TYPE_MODEL_MAPPING.get(n_type)):
-            raise PacketParseException(f"invalid notification type: {n_type}")
+            return None
 
         return p_model.model_validate(self.publish_payload)  # type: ignore
 


### PR DESCRIPTION
## 変更内容

MQTTパケットの空ペイロード処理を改善し、PacketParseExceptionを防ぎます。

- `packet.py`のpayloadプロパティで例外の代わりにNoneを返すように変更
- `client.py`で無効なペイロードをスキップするように検証を追加
- 空または無効なペイロードでもエラーにならず処理を継続

Fixes #129

---

## Changes

Improve MQTT empty payload handling to prevent PacketParseException.

- Change payload property in packet.py to return None instead of exception
- Add validation in client.py to skip invalid payloads
- Continue processing without errors for empty or invalid payloads

Fixes #129

---

Generated with [Claude Code](https://claude.ai/code)